### PR TITLE
CMake static OpenCV build for MSVC, update to OpenCV 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,16 @@ if(WIN32 AND NOT BUILD_SHARED_LIBS)
   # MSVC settings for static build
   # https://stackoverflow.com/a/14172871/12447766
   set(CompilerFlags
-        CMAKE_CXX_FLAGS
-        CMAKE_CXX_FLAGS_DEBUG
-        CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_C_FLAGS
-        CMAKE_C_FLAGS_DEBUG
-        CMAKE_C_FLAGS_RELEASE
-    )
-    foreach(CompilerFlag ${CompilerFlags})
-        string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
-    endforeach()
+    CMAKE_CXX_FLAGS
+    CMAKE_CXX_FLAGS_DEBUG
+    CMAKE_CXX_FLAGS_RELEASE
+    CMAKE_C_FLAGS
+    CMAKE_C_FLAGS_DEBUG
+    CMAKE_C_FLAGS_RELEASE
+  )
+  foreach(CompilerFlag ${CompilerFlags})
+    string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+  endforeach()
 endif(WIN32 AND NOT BUILD_SHARED_LIBS)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,22 +4,53 @@ project(egbis)
 if(WIN32)
   # put opencv_world???.dll near the final executable before running
   # which is located at "${OpenCV_DIR}/../bin"
-  set(OpenCV_DIR "C:/opencv/build/x64/vc15/lib")
+  # or add "${OpenCV_DIR}/../bin" to PATH environment variable
+  # cmake -D OpenCV_DIR="C:/opencv/build/x64/vc15" ..
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif(WIN32)
 
 find_package(OpenCV REQUIRED)
 
-add_compile_options(-Wall)
+if(WIN32 AND NOT BUILD_SHARED_LIBS)
+  # MSVC settings for static build
+  # https://stackoverflow.com/a/14172871/12447766
+  set(CompilerFlags
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG
+        CMAKE_C_FLAGS_RELEASE
+    )
+    foreach(CompilerFlag ${CompilerFlags})
+        string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+endif(WIN32 AND NOT BUILD_SHARED_LIBS)
+
+set(CMAKE_CXX_STANDARD 11)
 if(NOT WIN32)
-  add_compile_options(-Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-pthread)
 endif(NOT WIN32)
 
-file(GLOB SOURCES egbis.cpp egbis/disjoint-set.cpp egbis/misc.cpp egbis/segment-graph.cpp egbis/filter.cpp egbis/segment-image.cpp egbis/imconv.cpp egbis/convolve.cpp)
+file(GLOB SOURCES
+  egbis.cpp
+  egbis/disjoint-set.cpp
+  egbis/misc.cpp
+  egbis/segment-graph.cpp
+  egbis/filter.cpp
+  egbis/segment-image.cpp
+  egbis/imconv.cpp
+  egbis/convolve.cpp
+)
 
-add_library(egbis SHARED ${SOURCES})
-target_link_libraries(egbis ${OpenCV_LIBS})
-target_include_directories(egbis PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+if(WIN32)
+  add_library(egbis_library STATIC ${SOURCES})
+else(WIN32)
+  add_library(egbis_library SHARED ${SOURCES})
+endif(WIN32)
+target_link_libraries(egbis_library ${OpenCV_LIBS})
+target_include_directories(egbis_library PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 add_executable(main main.cpp)
-target_link_libraries(main egbis)
+target_link_libraries(main egbis_library)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(WIN32)
   # put opencv_world???.dll near the final executable before running
   # which is located at "${OpenCV_DIR}/../bin"
   # or add "${OpenCV_DIR}/../bin" to PATH environment variable
-  # cmake -D OpenCV_DIR="C:/opencv/build/x64/vc15" ..
+  # cmake -D OpenCV_DIR="C:/opencv/build/x64/vc15/lib" ..
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif(WIN32)
 

--- a/egbis/convolve.cpp
+++ b/egbis/convolve.cpp
@@ -5,7 +5,7 @@ void convolve_even(image<float> *src, image<float> *dst,
 			  std::vector<float> &mask) {
   int width = src->width();
   int height = src->height();
-  int len = mask.size();
+  int len = static_cast<int>(mask.size());
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
@@ -25,7 +25,7 @@ void convolve_odd(image<float> *src, image<float> *dst,
 			 std::vector<float> &mask) {
   int width = src->width();
   int height = src->height();
-  int len = mask.size();
+  int len = static_cast<int>(mask.size());
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {

--- a/egbis/filter.cpp
+++ b/egbis/filter.cpp
@@ -22,13 +22,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
 #include "filter.h"
 
 void normalize(std::vector<float> &mask) {
-  int len = mask.size();
+  size_t len = mask.size();
   float sum = 0;
-  for (int i = 1; i < len; i++) {
+  for (size_t i = 1; i < len; i++) {
     sum += fabs(mask[i]);
   }
   sum = 2*sum + fabs(mask[0]);
-  for (int i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     mask[i] /= sum;
   }
 }
@@ -40,7 +40,7 @@ std::vector<float> make_fgauss(float sigma)
   std::vector<float> mask(len);
   for (int i = 0; i < len; i++)
   {
-    mask[i] = exp(-0.5 * square(i / sigma));
+    mask[i] = static_cast<float>(exp(-0.5 * square(i / sigma)));
   }
   return mask;
 }

--- a/egbis/imconv.cpp
+++ b/egbis/imconv.cpp
@@ -2,19 +2,20 @@
 #include "imutil.h"
 
 image<uchar> *imageRGBtoGRAY(image<rgb> *input) {
-  const float RED_WEIGHT = 0.299;
-  const float GREEN_WEIGHT = 0.587;
-  const float BLUE_WEIGHT = 0.114;
+  const double RED_WEIGHT = 0.299;
+  const double GREEN_WEIGHT = 0.587;
+  const double BLUE_WEIGHT = 0.114;
   int width = input->width();
   int height = input->height();
   image<uchar> *output = new image<uchar>(width, height, false);
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
-      imRef(output, x, y) = (uchar)
-	(imRef(input, x, y).r * RED_WEIGHT +
-	 imRef(input, x, y).g * GREEN_WEIGHT +
-	 imRef(input, x, y).b * BLUE_WEIGHT);
+      imRef(output, x, y) = static_cast<uchar>(
+        imRef(input, x, y).r * RED_WEIGHT +
+        imRef(input, x, y).g * GREEN_WEIGHT +
+        imRef(input, x, y).b * BLUE_WEIGHT
+      );
     }
   }
   return output;
@@ -55,7 +56,7 @@ image<float> *imageINTtoFLOAT(image<int> *input) {
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
-      imRef(output, x, y) = imRef(input, x, y);
+      imRef(output, x, y) = static_cast<float>(imRef(input, x, y));
     }
   }
   return output;  

--- a/main.cpp
+++ b/main.cpp
@@ -60,10 +60,10 @@ int save_switch_high = 1;
 
 float sigma_value;
 
-void switch_callback_sigma( int position ){
+void switch_callback_sigma( int position, void* ){
     sigma_switch_value = position;
 
-    sigma_value = (float)sigma_switch_value/10;
+    sigma_value = static_cast<float>(sigma_switch_value)/10;
 /*
     switch (sigma_switch_value) {
         case 0:
@@ -103,15 +103,15 @@ void switch_callback_sigma( int position ){
 */
 }
 
-void switch_callback_k( int position ){
+void switch_callback_k( int position, void* ){
     k_switch_value = position;
 }
 
-void switch_callback_c( int position ){
+void switch_callback_c( int position, void* ){
     c_switch_value = position;
 }
 
-void switch_callback_save( int position ){
+void switch_callback_save( int position, void* ){
 
     if (position == 1)
     {
@@ -122,13 +122,13 @@ void switch_callback_save( int position ){
     }
 }
 
-void switch_callback_run( int position ){
+void switch_callback_run( int position, void* ){
 
     if (position == 1)
     {
         // Calculate new EGBIS segmentation
         // (Mat *input, float sigma, float k, int min_size, int *numccs) {
-        egbisImage = runEgbisOnMat(img, sigma_value, (float)k_switch_value, (float)c_switch_value, &num_ccs);
+        egbisImage = runEgbisOnMat(img, sigma_value, static_cast<float>(k_switch_value), c_switch_value, &num_ccs);
         // Change image shown
         imshow( "EGBIS", egbisImage);
         run_switch_value = 0;
@@ -149,7 +149,7 @@ void switch_callback_run( int position ){
 int main(int argc, char **argv) {
 
     assert(argc > 1);
-    img = imread( argv[1], CV_LOAD_IMAGE_COLOR );
+    img = imread( argv[1], cv::IMREAD_COLOR );
 
     if( !img.data )
     {
@@ -164,18 +164,18 @@ int main(int argc, char **argv) {
     egbisImage = runEgbisOnMat(img, 0.5, 500, 200, &num_ccs);
 
     // 4. Present image
-    namedWindow( imageName , CV_WINDOW_AUTOSIZE );
+    namedWindow( imageName , cv::WINDOW_AUTOSIZE );
     imshow( imageName , img );
 
     // TODO: Change to C++ method
     // http://docs.opencv.org/modules/highgui/doc/user_interface.html#createtrackbar
-    cvCreateTrackbar("Sigma [x/10]",imageName, &sigma_switch_value, sigma_switch_high, switch_callback_sigma);
-    cvCreateTrackbar("k",imageName, &k_switch_value, k_switch_high, switch_callback_k);
-    cvCreateTrackbar("c",imageName, &c_switch_value, c_switch_high, switch_callback_c);
-    cvCreateTrackbar("Run",imageName, &run_switch_value, run_switch_high, switch_callback_run);
-    cvCreateTrackbar("Save EGBIS image",imageName, &save_switch_value, save_switch_high, switch_callback_save);
+    cv::createTrackbar("Sigma [x/10]", imageName, &sigma_switch_value, sigma_switch_high, switch_callback_sigma);
+    cv::createTrackbar("k",imageName, &k_switch_value, k_switch_high, switch_callback_k);
+    cv::createTrackbar("c",imageName, &c_switch_value, c_switch_high, switch_callback_c);
+    cv::createTrackbar("Run",imageName, &run_switch_value, run_switch_high, switch_callback_run);
+    cv::createTrackbar("Save EGBIS image",imageName, &save_switch_value, save_switch_high, switch_callback_save);
 
-    namedWindow( "EGBIS", CV_WINDOW_AUTOSIZE );
+    namedWindow( "EGBIS", cv::WINDOW_AUTOSIZE );
     imshow( "EGBIS", egbisImage);
 /*
     float sigma = atof(argv[1]);
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
     savePPM(seg, argv[5]);
 
     Mat gray_image;
-    cvtColor( image, gray_image, CV_BGR2GRAY );
+    cvtColor( image, gray_image, cv::COLOR_BGR2GRAY );
     imwrite( "../../images/tempImage.jpg", gray_image );
 */
     waitKey(0);


### PR DESCRIPTION
Do not set `OpenCV_DIR`, let user provide it. Example command is in CMakeLists.txt.

Tested with Ubuntu 18 GCC (OpenCV 3.4), and Windows MSVC with static OpenCV libraries (v4.5.2).